### PR TITLE
Slotted icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-enhanced-rich-text-editor",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Web Component providing rich text editor functionality. This component is fork of vaadin-rich-text-editor, with enhanced functionality.",
   "main": "vcf-enhanced-rich-text-editor.js",
   "author": "Vaadin Ltd",

--- a/src/vcf-enhanced-rich-text-editor-icons.js
+++ b/src/vcf-enhanced-rich-text-editor-icons.js
@@ -29,31 +29,31 @@ documentContainer.innerHTML = `
   <dom-module id="vcf-enhanced-rich-text-editor-icons">
     <template>
       <style>
-        [part~="toolbar-button-clean"]::before {
+        [part~="toolbar-button-clean-icon"]::before {
           content: var(--vaadin-rte-icons-clean);
         }
 
-        [part~="toolbar-button-image"]::before {
+        [part~="toolbar-button-image-icon"]::before {
           content: var(--vaadin-rte-icons-image);
         }
 
-        [part~="toolbar-button-link"]::before {
+        [part~="toolbar-button-link-icon"]::before {
           content: var(--vaadin-rte-icons-link);
         }
 
-        [part~="toolbar-button-list-bullet"]::before {
+        [part~="toolbar-button-list-bullet-icon"]::before {
           content: var(--vaadin-rte-icons-list-bullet);
         }
 
-        [part~="toolbar-button-list-ordered"]::before {
+        [part~="toolbar-button-list-ordered-icon"]::before {
           content: var(--vaadin-rte-icons-list-ordered);
         }
 
-        [part~="toolbar-button-redo"]::before {
+        [part~="toolbar-button-redo-icon"]::before {
           content: var(--vaadin-rte-icons-redo);
         }
 
-        [part~="toolbar-button-undo"]::before {
+        [part~="toolbar-button-undo-icon"]::before {
           content: var(--vaadin-rte-icons-undo);
         }
       </style>

--- a/src/vcf-enhanced-rich-text-editor-toolbar-styles.js
+++ b/src/vcf-enhanced-rich-text-editor-toolbar-styles.js
@@ -55,23 +55,23 @@ documentContainer.innerHTML = `
           transform: translate(-50%, -50%);
         }
 
-        [part~="toolbar-button-undo"]::before,
-        [part~="toolbar-button-redo"]::before,
-        [part~="toolbar-button-list-ordered"]::before,
-        [part~="toolbar-button-list-bullet"]::before,       
-        [part~="toolbar-button-image"]::before,
-        [part~="toolbar-button-link"]::before,
-        [part~="toolbar-button-clean"]::before {
+        [part~="toolbar-button-undo-icon"]::before,
+        [part~="toolbar-button-redo-icon"]::before,
+        [part~="toolbar-button-list-ordered-icon"]::before,
+        [part~="toolbar-button-list-bullet.icon"]::before,       
+        [part~="toolbar-button-image-icon"]::before,
+        [part~="toolbar-button-link-icon"]::before,
+        [part~="toolbar-button-clean-icon"]::before {
           font-family: "vaadin-rte-icons", sans-serif;
         }    
 
-        [part~="toolbar-button-align-justify"] vaadin-icon, 
-        [part~="toolbar-button-align-left"] vaadin-icon,
-        [part~="toolbar-button-align-center"] vaadin-icon,
-        [part~="toolbar-button-align-right"] vaadin-icon,
-        [part~="toolbar-button-deindent"] vaadin-icon, 
-        [part~="toolbar-button-indent"] vaadin-icon,
-        [part~="toolbar-button-readonly"] vaadin-icon {
+        [part~="toolbar-button-align-justify-icon"], 
+        [part~="toolbar-button-align-left-icon"],
+        [part~="toolbar-button-align-center-icon"],
+        [part~="toolbar-button-align-right-icon"],
+        [part~="toolbar-button-deindent-icon"], 
+        [part~="toolbar-button-indent-icon"],
+        [part~="toolbar-button-readonly-icon"] {
           --rte-extra-icons-stroke-color: var(--lumo-contrast-80pct);
         }
 
@@ -80,72 +80,72 @@ documentContainer.innerHTML = `
           margin: 0 0.5em;
         }
 
-        [part~="toolbar-button-bold"]::before {
+        [part~="toolbar-button-bold-icon"]::before {
           content: "B";
           font-weight: 700;
         }
 
-        [part~="toolbar-button-italic"]::before {
+        [part~="toolbar-button-italic-icon"]::before {
           content: "I";
           font-style: italic;
         }
 
-        [part~="toolbar-button-underline"]::before {
+        [part~="toolbar-button-underline-icon"]::before {
           content: "U";
           text-decoration: underline;
         }
 
-        [part~="toolbar-button-strike"]::before {
+        [part~="toolbar-button-strike-icon"]::before {
           content: "T";
           text-decoration: line-through;
         }
 
-        [part~="toolbar-button-h1"]::before {
+        [part~="toolbar-button-h1-icon"]::before {
           content: "H1";
           font-size: 1.25em;
         }
 
-        [part~="toolbar-button-h2"]::before {
+        [part~="toolbar-button-h2-icon"]::before {
           content: "H2";
           font-size: 1em;
         }
 
-        [part~="toolbar-button-h3"]::before {
+        [part~="toolbar-button-h3-icon"]::before {
           content: "H3";
           font-size: 0.875em;
         }
 
-        [part~="toolbar-button-h1"]::before,
-        [part~="toolbar-button-h2"]::before,
-        [part~="toolbar-button-h3"]::before {
+        [part~="toolbar-button-h1-icon"]::before,
+        [part~="toolbar-button-h2-icon"]::before,
+        [part~="toolbar-button-h3-icon"]::before {
           letter-spacing: -0.05em;
         }
 
-        [part~="toolbar-button-subscript"]::before,
-        [part~="toolbar-button-superscript"]::before {
+        [part~="toolbar-button-subscript-icon"]::before,
+        [part~="toolbar-button-superscript-icon"]::before {
           content: "X";
         }
 
-        [part~="toolbar-button-subscript"]::after,
-        [part~="toolbar-button-superscript"]::after {
+        [part~="toolbar-button-subscript-icon"]::after,
+        [part~="toolbar-button-superscript-icon"]::after {
           content: "2";
           position: absolute;
           top: 50%;
-          left: 70%;
+          left: 65%;
           font-size: 0.625em;
         }
 
-        [part~="toolbar-button-superscript"]::after {
+        [part~="toolbar-button-superscript-icon"]::after {
           top: 20%;
         }
 
-        [part~="toolbar-button-blockquote"]::before {
+        [part~="toolbar-button-blockquote-icon"]::before {
           content: "”";
           font-size: 2em;
           height: 0.6em;
         }
 
-        [part~="toolbar-button-code-block"]::before {
+        [part~="toolbar-button-code-block-icon"]::before {
           content: "</>";
           font-size: 0.875em;
         }

--- a/src/vcf-enhanced-rich-text-editor.js
+++ b/src/vcf-enhanced-rich-text-editor.js
@@ -436,7 +436,7 @@ Inline.order.push(PlaceholderBlot.blotName, ReadOnlyBlot.blotName, LinePartBlot.
     }
 
     static get version() {
-      return '2.0.1';
+      return '3.0.0';
     }
 
     static get properties() {

--- a/src/vcf-enhanced-rich-text-editor.js
+++ b/src/vcf-enhanced-rich-text-editor.js
@@ -937,10 +937,25 @@ Inline.order.push(PlaceholderBlot.blotName, ReadOnlyBlot.blotName, LinePartBlot.
           e.preventDefault();
           let index = buttons.indexOf(e.target);
           buttons[index].setAttribute('tabindex', '-1');
-          if (e.keyCode === 39 && ++index === buttons.length) {
-            index = 0;
-          } else if (e.keyCode === 37 && --index === -1) {
-            index = buttons.length - 1;
+
+          // need to get in consideration if placeholders or any other button are hidden
+          // or not when navigating through arrow keys
+          if (e.keyCode === 39) {
+            ++index;
+            while (index < buttons.length && this._isHiddenButton(buttons, index)) {
+              ++index;
+            }
+            if (index === buttons.length) {
+              index = buttons.indexOf(this._getFirstVisibleToolbarButton());
+            }
+          } else if (e.keyCode === 37) {
+            --index;
+            while (index > -1 && index < buttons.length && this._isHiddenButton(buttons, index)) {
+              --index;
+            }
+            if (index === -1) {
+              index = buttons.length - 1;
+            }
           }
           buttons[index].removeAttribute('tabindex');
           buttons[index].focus();
@@ -958,6 +973,10 @@ Inline.order.push(PlaceholderBlot.blotName, ReadOnlyBlot.blotName, LinePartBlot.
           this._markToolbarFocused();
         }
       });
+    }
+
+    _isHiddenButton(buttons, index) {
+      return buttons[index].hidden || buttons[index].style.display == 'none';
     }
 
     _markToolbarClicked() {
@@ -1940,7 +1959,7 @@ Inline.order.push(PlaceholderBlot.blotName, ReadOnlyBlot.blotName, LinePartBlot.
 
       const focusToolbar = () => {
         this._markToolbarFocused();
-        this._toolbar.querySelector('button:not([style*="display: none"]):not([style*="display:none"])').focus();
+        this._getFirstVisibleToolbarButton().focus();
       };
 
       const bindings = keyboard.bindings[key] || [];
@@ -1954,6 +1973,10 @@ Inline.order.push(PlaceholderBlot.blotName, ReadOnlyBlot.blotName, LinePartBlot.
         },
         ...bindings
       ];
+    }
+
+    _getFirstVisibleToolbarButton() {
+      return this._toolbar.querySelector('button:not([style*="display: none"]):not([style*="display:none"]):not([hidden])');
     }
 
     /**

--- a/src/vcf-enhanced-rich-text-editor.js
+++ b/src/vcf-enhanced-rich-text-editor.js
@@ -199,82 +199,162 @@ Inline.order.push(PlaceholderBlot.blotName, ReadOnlyBlot.blotName, LinePartBlot.
           <div part="toolbar">
             <span part="toolbar-group toolbar-group-history" style="display: [[_buttonGroupDisplay(toolbarButtons, 'history')]];">
               <!-- Undo and Redo -->
-              <button type="button" part="toolbar-button toolbar-button-undo" on-click="_undo" title$="[[i18n.undo]]" style="display: [[_buttonDisplay(toolbarButtons, 'undo')]];"></button>
-              <button type="button" part="toolbar-button toolbar-button-redo" on-click="_redo" title$="[[i18n.redo]]" style="display: [[_buttonDisplay(toolbarButtons, 'redo')]];"></button>
+              <button type="button" part="toolbar-button toolbar-button-undo" on-click="_undo" title$="[[i18n.undo]]" style="display: [[_buttonDisplay(toolbarButtons, 'undo')]];">
+                <slot name="undo">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-undo-icon"></vaadin-icon>
+                </slot>
+              </button>
+              <button type="button" part="toolbar-button toolbar-button-redo" on-click="_redo" title$="[[i18n.redo]]" style="display: [[_buttonDisplay(toolbarButtons, 'redo')]];">
+                <slot name="redo">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-redo-icon"></vaadin-icon>
+                </slot>
+              </button>
             </span>
 
             <span part="toolbar-group toolbar-group-emphasis" style="display: [[_buttonGroupDisplay(toolbarButtons, 'emphasis')]];">
               <!-- Bold -->
-              <button class="ql-bold" part="toolbar-button toolbar-button-bold" title$="[[i18n.bold]]" style="display: [[_buttonDisplay(toolbarButtons, 'bold')]];"></button>
+              <button class="ql-bold" part="toolbar-button toolbar-button-bold" title$="[[i18n.bold]]" style="display: [[_buttonDisplay(toolbarButtons, 'bold')]];">
+                <slot name="bold">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-bold-icon"></vaadin-icon>
+                </slot>
+              </button>
 
               <!-- Italic -->
-              <button class="ql-italic" part="toolbar-button toolbar-button-italic" title$="[[i18n.italic]]" style="display: [[_buttonDisplay(toolbarButtons, 'italic')]];"></button>
+              <button class="ql-italic" part="toolbar-button toolbar-button-italic" title$="[[i18n.italic]]" style="display: [[_buttonDisplay(toolbarButtons, 'italic')]];">
+                <slot name="italic">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-italic-icon"></vaadin-icon>
+                </slot>
+              </button>
 
               <!-- Underline -->
-              <button class="ql-underline" part="toolbar-button toolbar-button-underline" title$="[[i18n.underline]]" style="display: [[_buttonDisplay(toolbarButtons, 'underline')]];"></button>
+              <button class="ql-underline" part="toolbar-button toolbar-button-underline" title$="[[i18n.underline]]" style="display: [[_buttonDisplay(toolbarButtons, 'underline')]];">
+                <slot name="underline">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-underline-icon"></vaadin-icon>
+                </slot>
+              </button>
 
               <!-- Strike -->
-              <button class="ql-strike" part="toolbar-button toolbar-button-strike" title$="[[i18n.strike]]" style="display: [[_buttonDisplay(toolbarButtons, 'strike')]];"></button>
+              <button class="ql-strike" part="toolbar-button toolbar-button-strike" title$="[[i18n.strike]]" style="display: [[_buttonDisplay(toolbarButtons, 'strike')]];">
+                <slot name="strike">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-strike-icon"></vaadin-icon>
+                </slot>
+              </button>
             </span>
 
             <span part="toolbar-group toolbar-group-heading" style="display: [[_buttonGroupDisplay(toolbarButtons, 'heading')]];">
               <!-- Header buttons -->
-              <button type="button" class="ql-header" value="1" part="toolbar-button toolbar-button-h1" title$="[[i18n.h1]]" style="display: [[_buttonDisplay(toolbarButtons, 'h1')]];"></button>
-              <button type="button" class="ql-header" value="2" part="toolbar-button toolbar-button-h2" title$="[[i18n.h2]]" style="display: [[_buttonDisplay(toolbarButtons, 'h2')]];"></button>
-              <button type="button" class="ql-header" value="3" part="toolbar-button toolbar-button-h3" title$="[[i18n.h3]]" style="display: [[_buttonDisplay(toolbarButtons, 'h3')]];"></button>
+              <button type="button" class="ql-header" value="1" part="toolbar-button toolbar-button-h1" title$="[[i18n.h1]]" style="display: [[_buttonDisplay(toolbarButtons, 'h1')]];">
+                <slot name="h1">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-h1-icon"></vaadin-icon>
+                </slot>
+              </button>
+              <button type="button" class="ql-header" value="2" part="toolbar-button toolbar-button-h2" title$="[[i18n.h2]]" style="display: [[_buttonDisplay(toolbarButtons, 'h2')]];">
+                <slot name="h2">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-h2-icon"></vaadin-icon>
+                </slot>
+              </button>
+              <button type="button" class="ql-header" value="3" part="toolbar-button toolbar-button-h3" title$="[[i18n.h3]]" style="display: [[_buttonDisplay(toolbarButtons, 'h3')]];">
+                <slot name="h3">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-h3-icon"></vaadin-icon>
+                </slot>
+              </button>
             </span>
 
             <span part="toolbar-group toolbar-group-glyph-transformation" style="display: [[_buttonGroupDisplay(toolbarButtons, 'glyph-transformation')]];">
               <!-- Subscript and superscript -->
-              <button class="ql-script" value="sub" part="toolbar-button toolbar-button-subscript" title$="[[i18n.subscript]]" style="display: [[_buttonDisplay(toolbarButtons, 'subscript')]];"></button>
-              <button class="ql-script" value="super" part="toolbar-button toolbar-button-superscript" title$="[[i18n.superscript]]" style="display: [[_buttonDisplay(toolbarButtons, 'superscript')]];"></button>
+              <button class="ql-script" value="sub" part="toolbar-button toolbar-button-subscript" title$="[[i18n.subscript]]" style="display: [[_buttonDisplay(toolbarButtons, 'subscript')]];">
+                <slot name="subscript">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-subscript-icon"></vaadin-icon>
+                </slot>
+              </button>
+              <button class="ql-script" value="super" part="toolbar-button toolbar-button-superscript" title$="[[i18n.superscript]]" style="display: [[_buttonDisplay(toolbarButtons, 'superscript')]];">
+                <slot name="superscript">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-superscript-icon"></vaadin-icon>
+                </slot>
+              </button>
             </span>
 
             <span part="toolbar-group toolbar-group-list" style="display: [[_buttonGroupDisplay(toolbarButtons, 'list')]];">
               <!-- List buttons -->
-              <button type="button" class="ql-list" value="ordered" part="toolbar-button toolbar-button-list-ordered" title$="[[i18n.listOrdered]]" style="display: [[_buttonDisplay(toolbarButtons, 'listOrdered')]];"></button>
-              <button type="button" class="ql-list" value="bullet" part="toolbar-button toolbar-button-list-bullet" title$="[[i18n.listBullet]]" style="display: [[_buttonDisplay(toolbarButtons, 'listBullet')]];"></button>
+              <button type="button" class="ql-list" value="ordered" part="toolbar-button toolbar-button-list-ordered" title$="[[i18n.listOrdered]]" style="display: [[_buttonDisplay(toolbarButtons, 'listOrdered')]];">
+                <slot name="listOrdered">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-list-ordered-icon"></vaadin-icon>
+                </slot>
+              </button>
+              <button type="button" class="ql-list" value="bullet" part="toolbar-button toolbar-button-list-bullet" title$="[[i18n.listBullet]]" style="display: [[_buttonDisplay(toolbarButtons, 'listBullet')]];">
+                <slot name="listBullet">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-list-bullet-icon"></vaadin-icon>
+                </slot>
+              </button>
             </span>
 
             <span part="toolbar-group toolbar-group-indent" style="display: [[_buttonGroupDisplay(toolbarButtons, 'indent')]];">
               <!-- List buttons -->
               <button type="button" class="ql-indent" value="-1" part="toolbar-button toolbar-button-deindent" title$="[[i18n.deindent]]" style="display: [[_buttonDisplay(toolbarButtons, 'deindent')]];">
-                <vaadin-icon icon="vcf-erte-extra-icons:deindent-icon"></vaadin-icon>
+                <slot name="deindent">
+                  <vaadin-icon icon="vcf-erte-extra-icons:deindent-icon" part="toolbar-button-deindent-icon"></vaadin-icon>
+                </slot>
               </button>
               <button type="button" class="ql-indent" value="+1" part="toolbar-button toolbar-button-indent" title$="[[i18n.indent]]" style="display: [[_buttonDisplay(toolbarButtons, 'indent')]];">
-                <vaadin-icon icon="vcf-erte-extra-icons:indent-icon"></vaadin-icon>
+                <slot name="indent">
+                  <vaadin-icon icon="vcf-erte-extra-icons:indent-icon" part="toolbar-button-indent-icon"></vaadin-icon>
+                </slot>
               </button>
             </span>
 
             <span part="toolbar-group toolbar-group-alignment" style="display: [[_buttonGroupDisplay(toolbarButtons, 'alignment')]];">
               <!-- Align buttons -->
               <button type="button" class="ql-align" value="" part="toolbar-button toolbar-button-align-left" title$="[[i18n.alignLeft]]" style="display: [[_buttonDisplay(toolbarButtons, 'alignLeft')]];">
-                <vaadin-icon icon="vcf-erte-extra-icons:align-left-icon"></vaadin-icon>
+                <slot name="alignLeft">
+                  <vaadin-icon icon="vcf-erte-extra-icons:align-left-icon" part="toolbar-button-align-left-icon"></vaadin-icon>
+                </slot>
               </button>
               <button type="button" class="ql-align" value="center" part="toolbar-button toolbar-button-align-center" title$="[[i18n.alignCenter]]" style="display: [[_buttonDisplay(toolbarButtons, 'alignCenter')]];">
-                <vaadin-icon icon="vcf-erte-extra-icons:align-center-icon"></vaadin-icon>
+                <slot name="alignCenter">
+                  <vaadin-icon icon="vcf-erte-extra-icons:align-center-icon" part="toolbar-button-align-center-icon"></vaadin-icon>
+                </slot>
               </button>
               <button type="button" class="ql-align" value="right" part="toolbar-button toolbar-button-align-right" title$="[[i18n.alignRight]]" style="display: [[_buttonDisplay(toolbarButtons, 'alignRight')]];">
-                <vaadin-icon icon="vcf-erte-extra-icons:align-right-icon"></vaadin-icon>
+                <slot name="alignRight">
+                  <vaadin-icon icon="vcf-erte-extra-icons:align-right-icon" part="toolbar-button-align-right-icon"></vaadin-icon>
+                </slot>
               </button>
               <button type="button" class="ql-align" value="justify" part="toolbar-button toolbar-button-align-justify" title$="[[i18n.alignJustify]]" style="display: [[_buttonDisplay(toolbarButtons, 'alignJustify')]];">
-                <vaadin-icon icon="vcf-erte-extra-icons:align-justify-icon"></vaadin-icon>
+                <slot name="alignJustify">
+                  <vaadin-icon icon="vcf-erte-extra-icons:align-justify-icon" part="toolbar-button-align-justify-icon"></vaadin-icon>
+                </slot>
               </button>
             </span>
 
             <span part="toolbar-group toolbar-group-rich-text" style="display: [[_buttonGroupDisplay(toolbarButtons, 'rich-text')]];">
               <!-- Image -->
-              <button type="button" part="toolbar-button toolbar-button-image" title$="[[i18n.image]]" on-touchend="_onImageTouchEnd" on-click="_onImageClick" style="display: [[_buttonDisplay(toolbarButtons, 'image')]];"></button>
+              <button type="button" part="toolbar-button toolbar-button-image" title$="[[i18n.image]]" on-touchend="_onImageTouchEnd" on-click="_onImageClick" style="display: [[_buttonDisplay(toolbarButtons, 'image')]];">
+                <slot name="image">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-image-icon"></vaadin-icon>
+                </slot>
+              </button>
               <!-- Link -->
-              <button type="button" part="toolbar-button toolbar-button-link" title$="[[i18n.link]]" on-click="_onLinkClick" style="display: [[_buttonDisplay(toolbarButtons, 'link')]];"></button>
+              <button type="button" part="toolbar-button toolbar-button-link" title$="[[i18n.link]]" on-click="_onLinkClick" style="display: [[_buttonDisplay(toolbarButtons, 'link')]];">
+                <slot name="link">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-link-icon"></vaadin-icon>
+                </slot>
+              </button>
             </span>
 
             <span part="toolbar-group toolbar-group-block" style="display: [[_buttonGroupDisplay(toolbarButtons, 'block')]];">
               <!-- Blockquote -->
-              <button type="button" class="ql-blockquote" part="toolbar-button toolbar-button-blockquote" title$="[[i18n.blockquote]]" style="display: [[_buttonDisplay(toolbarButtons, 'blockquote')]];"></button>
+              <button type="button" class="ql-blockquote" part="toolbar-button toolbar-button-blockquote" title$="[[i18n.blockquote]]" style="display: [[_buttonDisplay(toolbarButtons, 'blockquote')]];">
+                <slot name="blockquote">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-blockquote-icon"></vaadin-icon>
+                </slot>
+              </button>
 
               <!-- Code block -->
-              <button type="button" class="ql-code-block" part="toolbar-button toolbar-button-code-block" title$="[[i18n.codeBlock]]" style="display: [[_buttonDisplay(toolbarButtons, 'codeBlock')]];"></button>
+              <button type="button" class="ql-code-block" part="toolbar-button toolbar-button-code-block" title$="[[i18n.codeBlock]]" style="display: [[_buttonDisplay(toolbarButtons, 'codeBlock')]];">
+                <slot name="codeBlock">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-code-block-icon"></vaadin-icon>
+                </slot>
+              </button>
 
               <!-- Placeholder -->
               <button id="placeholderBtn" type="button" class="ql-placeholder" part="toolbar-button toolbar-button-placeholder" title$="[[i18n.placeholder]]" style="display: [[_buttonDisplay(toolbarButtons, 'placeholder')]];" hidden>
@@ -290,11 +370,17 @@ Inline.order.push(PlaceholderBlot.blotName, ReadOnlyBlot.blotName, LinePartBlot.
             <span part="toolbar-group toolbar-group-format" style="display: [[_buttonGroupDisplay(toolbarButtons, 'format')]];">
               <!-- Read-only -->
               <button type="button" class="rte-readonly" part="toolbar-button toolbar-button-readonly" title$="[[i18n.readonly]]" style="display: [[_buttonDisplay(toolbarButtons, 'readonly')]];" on-click="_onReadonlyClick">
-                <vaadin-icon icon="vcf-erte-extra-icons:lock-icon"></vaadin-icon>
+                <slot name="readonly">
+                  <vaadin-icon icon="vcf-erte-extra-icons:lock-icon" part="toolbar-button-readonly-icon"></vaadin-icon>
+                </slot>
               </button>
 
               <!-- Clean -->
-              <button type="button" class="ql-clean" part="toolbar-button toolbar-button-clean" title$="[[i18n.clean]]" style="display: [[_buttonDisplay(toolbarButtons, 'clean')]];"></button>
+              <button type="button" class="ql-clean" part="toolbar-button toolbar-button-clean" title$="[[i18n.clean]]" style="display: [[_buttonDisplay(toolbarButtons, 'clean')]];">
+                <slot name="clean">
+                  <vaadin-icon part="toolbar-button-icon toolbar-button-clean-icon"></vaadin-icon>
+                </slot>
+              </button>
             </span>
 
             <span part="toolbar-group toolbar-group-custom">

--- a/theme/lumo/vcf-enhanced-rich-text-editor-styles.js
+++ b/theme/lumo/vcf-enhanced-rich-text-editor-styles.js
@@ -57,104 +57,113 @@ const richTextEditor = css`
           color: var(--lumo-contrast-90pct);
         }
 
-        [part~='toolbar-button']::before {
+        [part~='toolbar-button-icon']::before {
           font-family: 'lumo-icons', var(--lumo-font-family);
           font-size: var(--lumo-icon-size-m);
         }
 
-        [part~='toolbar-button-undo']::before {
+        [part~='toolbar-button-undo-icon']::before {
           content: var(--lumo-icons-undo);
         }
 
-        [part~='toolbar-button-redo']::before {
+        [part~='toolbar-button-redo-icon']::before {
           content: var(--lumo-icons-redo);
         }
 
-        [part~='toolbar-button-bold']::before,
-        [part~='toolbar-button-italic']::before,
-        [part~='toolbar-button-underline']::before,
-        [part~='toolbar-button-strike']::before {
+        [part~='toolbar-button-bold-icon']::before,
+        [part~='toolbar-button-italic-icon']::before,
+        [part~='toolbar-button-underline-icon']::before,
+        [part~='toolbar-button-strike-icon']::before {
           font-size: var(--lumo-font-size-m);
           font-weight: 600;
+          padding-left: 0.45em;
         }
 
-        [part~='toolbar-button-bold']::before {
-          font-weight: 700;
+        [part~='toolbar-button-bold-icon']::before {
+          font-weight: 700;          
         }
 
-        [part~='toolbar-button-h1']::before,
-        [part~='toolbar-button-h2']::before,
-        [part~='toolbar-button-h3']::before {
+        [part~='toolbar-button-italic-icon']::before {
+          padding-left: 0.60em;        
+        }
+
+        [part~='toolbar-button-h1-icon']::before,
+        [part~='toolbar-button-h2-icon']::before,
+        [part~='toolbar-button-h3-icon']::before {
           font-weight: 600;
+          padding-left: 0.25em;
         }
 
-        [part~='toolbar-button-h1']::before {
+        [part~='toolbar-button-h1-icon']::before {
           font-size: var(--lumo-font-size-m);
         }
 
-        [part~='toolbar-button-h2']::before {
+        [part~='toolbar-button-h2-icon']::before {
           font-size: var(--lumo-font-size-s);
         }
 
-        [part~='toolbar-button-h3']::before {
+        [part~='toolbar-button-h3-icon']::before {
           font-size: var(--lumo-font-size-xs);
         }
 
-        [part~='toolbar-button-subscript']::before,
-        [part~='toolbar-button-superscript']::before {
+        [part~='toolbar-button-subscript-icon']::before,
+        [part~='toolbar-button-superscript-icon']::before {
           font-weight: 600;
-          font-size: var(--lumo-font-size-s);
+          font-size: var(--lumo-font-size-s);          
+          padding-left: 0.35em;
         }
 
-        [part~='toolbar-button-subscript']::after,
-        [part~='toolbar-button-superscript']::after {
+        [part~='toolbar-button-subscript-icon']::after,
+        [part~='toolbar-button-superscript-icon']::after {
           font-size: 0.625em;
           font-weight: 700;
         }
 
-        [part~='toolbar-button-list-ordered']::before {
+        [part~='toolbar-button-list-ordered-icon']::before {
           content: var(--lumo-icons-ordered-list);
         }
 
-        [part~='toolbar-button-list-bullet']::before {
+        [part~='toolbar-button-list-bullet-icon']::before {
           content: var(--lumo-icons-unordered-list);
         }
 
-        [part~="toolbar-button-align-justify"] vaadin-icon, 
-        [part~="toolbar-button-align-left"] vaadin-icon,
-        [part~="toolbar-button-align-center"] vaadin-icon,
-        [part~="toolbar-button-align-right"] vaadin-icon,
-        [part~="toolbar-button-deindent"] vaadin-icon, 
-        [part~="toolbar-button-indent"] vaadin-icon,
-        [part~="toolbar-button-readonly"] vaadin-icon {
+        [part~="toolbar-button-align-justify-icon"], 
+        [part~="toolbar-button-align-left-icon"],
+        [part~="toolbar-button-align-center-icon"],
+        [part~="toolbar-button-align-right-icon"],
+        [part~="toolbar-button-deindent-icon"], 
+        [part~="toolbar-button-indent-icon"],
+        [part~="toolbar-button-readonly-icon"] {
           --rte-extra-icons-stroke-color: var(--lumo-contrast-60pct);
         }
-
         
-        [part~='toolbar-button-blockquote']::before {
+        [part~='toolbar-button-blockquote-icon']::before {
           font-size: var(--lumo-font-size-xxl);
+          padding-left: 0.25em;
         }
 
-        [part~='toolbar-button-code-block']::before {
+        [part~='toolbar-button-code-block-icon']::before {
           content: var(--lumo-icons-angle-left) var(--lumo-icons-angle-right);
           font-size: var(--lumo-font-size-l);
           letter-spacing: -0.5em;
           margin-left: -0.25em;
           font-weight: 600;
+          padding-left: 0.20em;
         }
 
-        [part~='toolbar-button-image']::before {
+        [part~='toolbar-button-image-icon']::before {
           content: var(--lumo-icons-photo);
         }
 
-        [part~='toolbar-button-link']::before {
+        [part~='toolbar-button-link-icon']::before {
           font-family: 'vaadin-rte-icons';
           font-size: var(--lumo-icon-size-m);
         }
 
-        [part~='toolbar-button-clean']::before {
+        [part~='toolbar-button-clean-icon']::before {
           font-family: 'vaadin-rte-icons';
           font-size: var(--lumo-font-size-l);
+          padding-left: 0.20em;
         }
 
         [part='content'] {

--- a/theme/material/vcf-enhanced-rich-text-editor-styles.js
+++ b/theme/material/vcf-enhanced-rich-text-editor-styles.js
@@ -50,33 +50,33 @@ const richTextEditor = css`
         }
 
         /* SVG icons */
-        [part~='toolbar-button-undo']::before,
-        [part~='toolbar-button-redo']::before,
-        [part~='toolbar-button-list-ordered']::before,
-        [part~='toolbar-button-list-bullet']::before,
-        [part~='toolbar-button-image']::before,
-        [part~='toolbar-button-link']::before,
-        [part~='toolbar-button-clean']::before {
+        [part~='toolbar-button-undo-icon']::before,
+        [part~='toolbar-button-redo-icon']::before,
+        [part~='toolbar-button-list-ordered-icon']::before,
+        [part~='toolbar-button-list-bullet-icon']::before,
+        [part~='toolbar-button-image-icon']::before,
+        [part~='toolbar-button-link-icon']::before,
+        [part~='toolbar-button-clean-icon']::before {
           font-size: 24px;
           font-weight: 400;
         }
 
         /* Text icons */
-        [part~='toolbar-button-bold']::before,
-        [part~='toolbar-button-italic']::before,
-        [part~='toolbar-button-underline']::before,
-        [part~='toolbar-button-strike']::before {
+        [part~='toolbar-button-bold-icon']::before,
+        [part~='toolbar-button-italic-icon']::before,
+        [part~='toolbar-button-underline-icon']::before,
+        [part~='toolbar-button-strike-icon']::before {
           font-size: 20px;
         }
 
         /* SVG extra icon set */
-        [part~="toolbar-button-align-justify"] vaadin-icon, 
-        [part~="toolbar-button-align-left"] vaadin-icon,
-        [part~="toolbar-button-align-center"] vaadin-icon,
-        [part~="toolbar-button-align-right"] vaadin-icon,
-        [part~="toolbar-button-deindent"] vaadin-icon, 
-        [part~="toolbar-button-indent"] vaadin-icon,
-        [part~="toolbar-button-readonly"] vaadin-icon {
+        [part~="toolbar-button-align-justify-icon"], 
+        [part~="toolbar-button-align-left-icon"],
+        [part~="toolbar-button-align-center-icon"],
+        [part~="toolbar-button-align-right-icon"],
+        [part~="toolbar-button-deindent-icon"], 
+        [part~="toolbar-button-indent-icon"],
+        [part~="toolbar-button-readonly-icon"] {
           --rte-extra-icons-stroke-color: var(--material-secondary-text-color);
         }
 


### PR DESCRIPTION
This PR includes:

* a fix to arrows navigation that stopped working when navigation reached hidden buttons
* make toolbar standard buttons to include an slot for the icon, so icons can be replaced easily if wanted. As the upgrade includes some styling changes, the commit it's understood to be a breaking change so the component version has been updated to 3.0.0.
